### PR TITLE
Refactor walkbot to start polling immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # zulip-walkbot
-A bot for the walking group at @recursecenter
+
+A bot for the walking group at @recursecenter.
+
+## Usage
+
+Currently when the words "walkbot" are said with any sort of capitalization, in any Recurse Center Zulip thread, WalkBot will respond with a message describing the weather and the pridicted weather for the next hour.
+
+## Deployment
+
+Heroku autopushes from the master branch of this repo. The heroku project is `walk-bot` and owned by `Nat Welch (SP2'15)`. Ping him if you would like access to the bot or if something is wrong.
+
+# Future changes
+
+This is a list of suggested projects:
+
+ - Add auto walk announcements
+ - Create suggested walks
+ - Look at all weather for the day and suggest a good walk time if it will be a bad time at 1500.

--- a/bot.rb
+++ b/bot.rb
@@ -187,6 +187,33 @@ def post_message stream, topic, message
   return false
 end
 
+def create_polling_thread queue_id, last_msg_id
+  thr = Thread.new(queue_id, last_msg_id) do |queue_id, last_msg_id|
+
+    raise "Queue ID was nil" if queue_id.nil?
+    last_msg_id = -1 if last_msg_id.nil?
+
+    while true do
+      p "Checking for messages."
+      $stdout.flush
+      response = get_most_recent_msgs(queue_id, last_msg_id, true)
+
+      response.each do |ev|
+        if ev["type"] == "message"
+          msg = ev["message"]
+          last_msg_id = msg["id"]
+          content = msg["content"]
+          stream = msg["display_recipient"]
+          topic = msg["subject"]
+          if content =~ /WalkBot/i
+            post_message(stream, topic, format_weather(weather))
+          end
+        end
+      end
+    end
+  end
+end
+
 configure do
   BOT_EMAIL_ADDRESS = ENV["BOT_EMAIL_ADDRESS"]
   BOT_API_KEY = ENV["BOT_API_KEY"]
@@ -194,6 +221,7 @@ configure do
 
   subscribe_all
   @queue_id, @last_msg_id = register
+  create_polling_thread(@queue_id, @last_msg_id)
 end
 
 get "/" do
@@ -206,29 +234,19 @@ get "/weather.json" do
 end
 
 get "/poll" do
-  @queue_id, @last_msg_id = register if @queue_id.nil?
-
-  thr = Thread.new do
-    while true do
-      response = get_most_recent_msgs(@queue_id, @last_msg_id, true)
-
-      response.each do |ev|
-        if ev["type"] == "message"
-          msg = ev["message"]
-          @last_msg_id = msg["id"]
-          content = msg["content"]
-          stream = msg["display_recipient"]
-          topic = msg["subject"]
-          if content =~ /WalkBot/i
-            post_message(stream, topic, format_weather(weather))
-          end
-        end
-      end
-    end
+  Thread.list.each do |t|
+    t.kill
   end
 
+  @queue_id, @last_msg_id = register if @queue_id.nil?
+  create_polling_thread(@queue_id, @last_msg_id)
+
+  redirect "/status.json"
+end
+
+get "/status.json" do
   content_type :json
-  "running - #{thr.inspect}"
+  Thread.list.to_json
 end
 
 after do


### PR DESCRIPTION
Right now the bot needs someone to hit `/poll` to start polling for data. Lets change this to start polling almost immediately.
